### PR TITLE
Fix instance_id, skip_install & resource name-spacing 

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,10 @@ resource "aws_volume_attachment" "game_volume_attachment" {
 | region | The aws region. Choose the one closest to you: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions | `string` | |
 | allowed_availability_zone_identifier | The allowed availability zone identify (the letter suffixing the region). Choose ones that allows you to request the desired instance as spot instance in your region. An availability zone will be selected at random and the instance will be booted in it. | `list(string)` | ["a", "b"] |
 | instance_type | The aws instance type, Choose one with a CPU/GPU that fits your need: https://aws.amazon.com/ec2/instance-types/#Accelerated_Computing | `string` | "g4dn.xlarge" |
+| resource_name | Name with which to prefix resources in AWS | `string` | `cloud-gaming` |
 | root_block_device_size_gb | The size of the root block device (C:\\ drive) attached to the instance | `number` | 120 |
 | custom_ami | Use the specified ami instead of the most recent windows ami in available in the region | `string` | "" |
+| skip_install | Skip installation step on startup. Useful when using a custom AMI that is already setup | `bool` | false |
 | install_parsec | Download and run Parsec-Cloud-Preparation-Tool on first login | `bool` | true |
 | install_auto_login | Configure auto-login on first boot | `bool` | true |
 | install_graphic_card_driver | Download and install the Nvidia driver on first boot | `bool` | true |
@@ -101,4 +103,5 @@ resource "aws_volume_attachment" "game_volume_attachment" {
 | --- | --- | --- |
 | instance_id | The id of the instance | `string` |
 | instance_ip | The ip address of the instance. Use it to connect | `string` |
+| instance_public_dns | The dns address of the instance. Use it to connect | `string` |
 | instance_password | The Administrator password of the instance. Use it to connect | `string` |

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ resource "random_password" "password" {
 }
 
 resource "aws_ssm_parameter" "password" {
-  name = "cloud-gaming-administrator-password"
+  name = "${var.resource_name}-administrator-password"
   type = "SecureString"
   value = random_password.password.result
 
@@ -42,7 +42,7 @@ resource "aws_ssm_parameter" "password" {
 }
 
 resource "aws_security_group" "default" {
-  name = "cloud-gaming-sg"
+  name = "${var.resource_name}-sg"
 
   tags = {
     App = "aws-cloud-gaming"
@@ -83,7 +83,7 @@ resource "aws_security_group_rule" "default" {
 }
 
 resource "aws_iam_role" "windows_instance_role" {
-  name = "cloud-gaming-instance-role"
+  name = "${var.resource_name}-instance-role"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -106,7 +106,7 @@ EOF
 }
 
 resource "aws_iam_policy" "password_get_parameter_policy" {
-  name = "password-get-parameter-policy"
+  name = "${var.resource_name}-password-get-parameter-policy"
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -136,7 +136,7 @@ resource "aws_iam_role_policy_attachment" "driver_get_object_policy_attachment" 
 }
 
 resource "aws_iam_instance_profile" "windows_instance_profile" {
-  name = "cloud-gaming-instance-profile"
+  name = "${var.resource_name}-instance-profile"
   role = aws_iam_role.windows_instance_role.name
 }
 
@@ -172,7 +172,7 @@ resource "aws_spot_instance_request" "windows_instance" {
   }
 
   tags = {
-    Name = "cloud-gaming-instance"
+    Name = "${var.resource_name}-instance"
     App = "aws-cloud-gaming"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -192,7 +192,7 @@ resource "aws_spot_instance_request" "windows_instance" {
 }
 
 output "instance_id" {
-  value = aws_spot_instance_request.windows_instance.id
+  value = aws_spot_instance_request.windows_instance.spot_instance_id
 }
 
 output "instance_ip" {

--- a/main.tf
+++ b/main.tf
@@ -120,23 +120,9 @@ resource "aws_iam_policy" "password_get_parameter_policy" {
 }
 EOF
 }
-resource "aws_iam_policy" "driver_get_object_policy" {
-  name = "driver-get-object-policy"
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:ListBucket",
-        "s3:GetObject"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-EOF
+
+data "aws_iam_policy" "driver_get_object_policy" {
+  arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
 }
 
 resource "aws_iam_role_policy_attachment" "password_get_parameter_policy_attachment" {
@@ -146,7 +132,7 @@ resource "aws_iam_role_policy_attachment" "password_get_parameter_policy_attachm
 
 resource "aws_iam_role_policy_attachment" "driver_get_object_policy_attachment" {
   role = aws_iam_role.windows_instance_role.name
-  policy_arn = aws_iam_policy.driver_get_object_policy.arn
+  policy_arn = data.aws_iam_policy.driver_get_object_policy.arn
 }
 
 resource "aws_iam_instance_profile" "windows_instance_profile" {

--- a/main.tf
+++ b/main.tf
@@ -185,6 +185,10 @@ output "instance_ip" {
   value = aws_spot_instance_request.windows_instance.public_ip
 }
 
+output "instance_public_dns" {
+  value = aws_spot_instance_request.windows_instance.public_dns
+}
+
 output "instance_password" {
   value = random_password.password.result
   sensitive = true

--- a/main.tf
+++ b/main.tf
@@ -159,7 +159,7 @@ resource "aws_spot_instance_request" "windows_instance" {
   availability_zone = local.availability_zone
   ami = (length(var.custom_ami) > 0) ? var.custom_ami : data.aws_ami.windows_ami.image_id
   security_groups = [aws_security_group.default.name]
-  user_data = templatefile("${path.module}/templates/user_data.tpl", {
+  user_data = var.skip_install ? "" : templatefile("${path.module}/templates/user_data.tpl", {
     password_ssm_parameter=aws_ssm_parameter.password.name,
     var={
       instance_type=var.instance_type,
@@ -172,7 +172,7 @@ resource "aws_spot_instance_request" "windows_instance" {
       install_epic_games_launcher=var.install_epic_games_launcher,
       install_uplay=var.install_uplay,
     }
-    })
+  })
   iam_instance_profile = aws_iam_instance_profile.windows_instance_profile.id
 
   # Spot configuration

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,13 @@ variable "custom_ami" {
   default = ""
 }
 
+
+variable "skip_install" {
+  description = "When starting from an AMI that is already setup there is no need to install everything again on startup"
+  type = bool
+  default = false
+}
+
 variable "install_parsec" {
   description = "Download and run Parsec-Cloud-Preparation-Tool on first login"
   type = bool

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "region" {
   type = string
 }
 
+variable "resource_name" {
+  description = "Name to prefix to all resources in AWS"
+  type = string
+  default = "cloud-gaming"
+}
+
 variable "allowed_availability_zone_identifier" {
   description = "The allowed availability zone identify (the letter suffixing the region). Choose ones that allows you to request the desired instance as spot instance in your region. An availability zone will be selected at random and the instance will be booted in it."
   type = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,7 @@ variable "region" {
 }
 
 variable "resource_name" {
-  description = "Name to prefix to all resources in AWS"
+  description = "Name with which to prefix resources in AWS"
   type = string
   default = "cloud-gaming"
 }
@@ -35,7 +35,7 @@ variable "custom_ami" {
 
 
 variable "skip_install" {
-  description = "When starting from an AMI that is already setup there is no need to install everything again on startup"
+  description = "Skip installation step on startup. Useful when using a custom AMI that is already setup"
   type = bool
   default = false
 }


### PR DESCRIPTION
Nice project, thanks a lot!

I'm trying to use this as a terraform module, and I had to make a few changes to get my use-case working. I'll leave those here incase you want to include them in this project.

My use-case is just to create some scripts to automate creating snapshots & an AMI of the instance before destroying it (using `aws_ami_from_instance`). It means I don't need to install everything / login to steam & parsec again the next time. https://github.com/Marcel-G/aws-cloud-gaming-control

To get my project working with this module I made these changes:

- Fix `instance_id` output - it was returning the id of the spot request rather than the running ec2 instance
- Add `skip_install` flag - You may want to start up from a `custom_ami` that has already been setup.
This will skip all the installation steps to speed up startup
- Add means to namespace resources incase you want to run many instances